### PR TITLE
Compatible with py2 and py3

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -26,6 +26,7 @@ you indices look like `logstash-2017.10.30`.
 * `prefix` - A prefix for the resource names, this helps create multiple
 instances of this stack for different environments and regions.
 * `schedule` - Schedule expression for running the cleanup function.
+* `python_version` - Python version to be used. Defaults to 2.7
 Default is once a day at 03:00 GMT.
 See: http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
 
@@ -41,5 +42,6 @@ module "es_cleanup" {
   index        = "logstash"
   delete_after = 60
   index_format = "%Y.%m.%d"
+  python_version = "3.6"
 }
 ```

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "es_cleanup" {
     filename         = "${path.module}/es-cleanup.zip"
     function_name    = "${var.prefix}es-cleanup"
     timeout          = 300
-    runtime          = "python2.7"
+    runtime          = "python${var.python_version}"
     role             = "${aws_iam_role.role.arn}"
     handler          = "es-cleanup.lambda_handler"
     source_code_hash = "${data.archive_file.es_cleanup_lambda.output_base64sha256}"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -11,3 +11,5 @@ variable "index" {}
 variable "delete_after" {}
 
 variable "index_format" {}
+
+variable "python_version" { default = "2.7" }


### PR DESCRIPTION
This should work with python versions 2 and 3.

Also, it seems to me that if the indice name contained "-" the cleaner didn't work as expected. With these changes it seems it does.