### PR TITLE
VPC support for the Lambda function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ __pycache__/
 # C extensions
 *.so
 
+**/.terraform
+**/terraform.tfstate*
+
+**/*es-cleanup.zip
 .serverless
 # Distribution / packaging
 .Python

--- a/README.md
+++ b/README.md
@@ -85,16 +85,16 @@ Create your AWS Cloudwatch rule:
 $ aws events put-rule \
 	--name my-scheduled-rule \
 	--schedule-expression 'cron(0 1 * * ? *)'
-    
-    
+
+
 $ aws lambda add-permission \
 	--function-name es-cleanup-lambda \
 	--statement-id my-scheduled-event \
 	--action 'lambda:InvokeFunction' \
 	--principal events.amazonaws.com \
 	--source-arn arn:aws:events:eu-west-1:123456789012:rule/my-scheduled-rule    
-    
-    
+
+
 $ aws events put-targets \
 	--rule my-scheduled-rule \
 	--targets file://json_file/cloudwatch-target.json
@@ -104,13 +104,13 @@ $ aws events put-targets \
 
 Using AWS environment variable you can easily modify the behaviour of the Lambda function
 
-| Variable Name | Example Value | Description | Default Value | Required | 
+| Variable Name | Example Value | Description | Default Value | Required |
 | --- | --- | --- | --- |  --- |
-| es_endpoint | search-es-demo-zveqnhnhjqm5flntemgmx5iuya.eu-west-1.es.amazonaws.com  | AWS ES fqdn | `None` | True | 
+| es_endpoint | search-es-demo-zveqnhnhjqm5flntemgmx5iuya.eu-west-1.es.amazonaws.com  | AWS ES fqdn | `None` | True |
 | index |  `logstash,cwl` | Index/indices to process comma separated, with `all` every index will be processed except `.kibana` | `all` | False |
-| index_format  | `%Y.%m.%d` | Combined with `index` varible is used to evaluate the index age | `%Y.%m.%d` |  False | 
-| delete_after | `7` | Numbers of days to preserve | `15` |  False | 
-| sns_alert | `arn:aws:sns:eu-west-1:123456789012:sns-alert` | SNS ARN to pusblish any alert | | False |
+| index_format  | `%Y.%m.%d` | Combined with `index` varible is used to evaluate the index age | `%Y.%m.%d` |  False |
+| delete_after | `7` | Numbers of days to preserve | `15` |  False |
+| sns_alert | `arn:aws:sns:eu-west-1:123456789012:sns-alert` | SNS ARN to publish any alert | | False |
 
 ## Serverless Framework
 
@@ -144,7 +144,7 @@ functions:
   es-cleanup-lambda: es-cleanup-lambda-prod-es-cleanup-lambda
 ```
 
-### Terraform deployment 
+### Terraform deployment
 
 This lambda function can be also build using terraform followings this [README](terraform/README.md).
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -30,21 +30,21 @@ Particularly it creates:
 
 ```
 module "public_es_cleanup" {
-  source = "github.com/cloudreach/aws-lambda-es-cleanup.git//terraform"
+  source       = "github.com/cloudreach/aws-lambda-es-cleanup.git//terraform"
 
   prefix       = "public_es_"
   es_endpoint  = "test-es-XXXXXXX.eu-central-1.es.amazonaws.com"
-  delete_after = 60
+  delete_after = 365
 }
 
 
 module "vpc_es_cleanup" {
-  source = "github.com/cloudreach/aws-lambda-es-cleanup.git//terraform"
+  source       = "github.com/cloudreach/aws-lambda-es-cleanup.git//terraform"
 
   prefix       = "vpc_es_"
   es_endpoint  = "vpc-gc-demo-vpc-gloo5rzcdhyiykwdlots2hdjla.eu-central-1.es.amazonaws.com"
   index        = "all"
   delete_after = 30
-  subnet_ids     = ["subnet-d8660da2"]
+  subnet_ids   = ["subnet-d8660da2"]
 }
 ```

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -8,6 +8,7 @@ Particularly it creates:
 1. Lambda function that does the deletion
 2. IAM role and policy that allows access to ES
 3. Cloudwatch event rule that triggers the lambda function on a schedule
+4. (Only when your Lambda is deployed inside a VPC) Securitygroup for Lambda function
 
 ## Module Input Variables
 
@@ -29,7 +30,8 @@ instances of this stack for different environments and regions.
 * `python_version` - Python version to be used. Defaults to 2.7
 Default is once a day at 03:00 GMT.
 See: http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
-
+* `subnet_ids` - Subnet IDs you want to deploy the lambda in. Only fill this in if you want to deploy your Lambda function inside a VPC.
+* `elasticsearch_sg_id` - Security group ID of the AWS elasticsearch service. Only fill this in if you deploy Lambda function inside a VPC.
 ## Usage
 
 ```

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,29 +19,14 @@ Particularly it creates:
 | index |  `logstash,cwl` | Index/indices to process comma separated, with `all` every index will be processed except `.kibana` | `all` | False |
 | index_format  | `%Y.%m.%d` | Combined with `index` varible is used to evaluate the index age | `%Y.%m.%d` |  False |
 | delete_after | `7` | Numbers of days to preserve | `15` |  False |
+| python_version | `2.7` | Python version to be used | `2.7` |  False |
+| schedule | `cron(0 3 * * ? *)` | Cron Schedule expression for running the cleanup function | `cron(0 3 * * ? *)` |  False |
 | sns_alert | `arn:aws:sns:eu-west-1:123456789012:sns-alert` | SNS ARN to publish any alert | | False |
 | prefix | `public-` | A prefix for the resource names, this helps create multiple instances of this stack for different environments | | False |
+| subnet_ids | `["subnet-1111111", "subnet-222222"]` | Subnet IDs you want to deploy the lambda in. Only fill this in if you want to deploy your Lambda function inside a VPC. | | False |
 
-### Required
 
-* `es_endpoint` - Elasticsearch endpoint.
-
-### Optional
-
-* `index` - Prefix of the index names. e.g. `logstash` if your indices look
-like `logstash-2017.10.30`.
-* `delete_after` - How many days old to keep. Default 7
-* `index_format` - Variable section of the index names, if
-you indices look like `logstash-2017.10.30`. Default `%Y.%m.%d`
-* `sns_alert` - SNS topic ARN to send failure alerts to.
-* `prefix` - A prefix for the resource names, this helps create multiple
-instances of this stack for different environments and regions.
-* `schedule` - Schedule expression for running the cleanup function.
-* `python_version` - Python version to be used. Defaults to 2.7
-Default is once a day at 03:00 GMT.
-See: http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
-* `subnet_ids` - Subnet IDs you want to deploy the lambda in. Only fill this in if you want to deploy your Lambda function inside a VPC.
-## Usage
+## Example
 
 ```
 module "public_es_cleanup" {

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -12,17 +12,27 @@ Particularly it creates:
 
 ## Module Input Variables
 
+
+| Variable Name | Example Value | Description | Default Value | Required |
+| --- | --- | --- | --- |  --- |
+| es_endpoint | search-es-demo-zveqnhnhjqm5flntemgmx5iuya.eu-west-1.es.amazonaws.com  | AWS ES fqdn | `None` | True |
+| index |  `logstash,cwl` | Index/indices to process comma separated, with `all` every index will be processed except `.kibana` | `all` | False |
+| index_format  | `%Y.%m.%d` | Combined with `index` varible is used to evaluate the index age | `%Y.%m.%d` |  False |
+| delete_after | `7` | Numbers of days to preserve | `15` |  False |
+| sns_alert | `arn:aws:sns:eu-west-1:123456789012:sns-alert` | SNS ARN to publish any alert | | False |
+| prefix | `public-` | A prefix for the resource names, this helps create multiple instances of this stack for different environments | | False |
+
 ### Required
 
 * `es_endpoint` - Elasticsearch endpoint.
-* `index` - Prefix of the index names. e.g. `logstash` if your indices look
-like `logstash-2017.10.30`.
-* `delete_after` - How many days old to keep.
-* `index_format` - Variable section of the index names. e.g. `%Y.%m.%d` if
-you indices look like `logstash-2017.10.30`.
 
 ### Optional
 
+* `index` - Prefix of the index names. e.g. `logstash` if your indices look
+like `logstash-2017.10.30`.
+* `delete_after` - How many days old to keep. Default 7
+* `index_format` - Variable section of the index names, if
+you indices look like `logstash-2017.10.30`. Default `%Y.%m.%d`
 * `sns_alert` - SNS topic ARN to send failure alerts to.
 * `prefix` - A prefix for the resource names, this helps create multiple
 instances of this stack for different environments and regions.
@@ -31,19 +41,25 @@ instances of this stack for different environments and regions.
 Default is once a day at 03:00 GMT.
 See: http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
 * `subnet_ids` - Subnet IDs you want to deploy the lambda in. Only fill this in if you want to deploy your Lambda function inside a VPC.
-* `elasticsearch_sg_id` - Security group ID of the AWS elasticsearch service. Only fill this in if you deploy Lambda function inside a VPC.
 ## Usage
 
 ```
-module "es_cleanup" {
+module "public_es_cleanup" {
   source = "github.com/cloudreach/aws-lambda-es-cleanup.git//terraform"
 
-  prefix       = "test-eu-central-1-"
+  prefix       = "public_es_"
   es_endpoint  = "test-es-XXXXXXX.eu-central-1.es.amazonaws.com"
-  sns_alert    = "arn:aws:sns:eu-central-1:123456789012:alertme"
-  index        = "logstash"
   delete_after = 60
-  index_format = "%Y.%m.%d"
-  python_version = "3.6"
+}
+
+
+module "vpc_es_cleanup" {
+  source = "github.com/cloudreach/aws-lambda-es-cleanup.git//terraform"
+
+  prefix       = "vpc_es_"
+  es_endpoint  = "vpc-gc-demo-vpc-gloo5rzcdhyiykwdlots2hdjla.eu-central-1.es.amazonaws.com"
+  index        = "all"
+  delete_after = 30
+  subnet_ids     = ["subnet-d8660da2"]
 }
 ```

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -5,15 +5,33 @@ resource "aws_cloudwatch_event_rule" "schedule" {
 }
 
 resource "aws_cloudwatch_event_target" "es_cleanup" {
+  count     = "${length(var.subnet_ids) == 0 ? 1 : 0}"
   target_id = "${var.prefix}lambda-es-cleanup"
   rule      = "${aws_cloudwatch_event_rule.schedule.name}"
   arn       = "${aws_lambda_function.es_cleanup.arn}"
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch" {
+  count         = "${length(var.subnet_ids) == 0 ? 1 : 0}"
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
   function_name = "${aws_lambda_function.es_cleanup.arn}"
+  principal     = "events.amazonaws.com"
+  source_arn    = "${aws_cloudwatch_event_rule.schedule.arn}"
+}
+
+resource "aws_cloudwatch_event_target" "es_cleanup_vpc" {
+  count     = "${length(var.subnet_ids) > 0 ? 1 : 0}"
+  target_id = "${var.prefix}lambda-es-cleanup"
+  rule      = "${aws_cloudwatch_event_rule.schedule.name}"
+  arn       = "${aws_lambda_function.es_cleanup_vpc.arn}"
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_vpc" {
+  count         = "${length(var.subnet_ids) > 0 ? 1 : 0}"
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.es_cleanup_vpc.arn}"
   principal     = "events.amazonaws.com"
   source_arn    = "${aws_cloudwatch_event_rule.schedule.arn}"
 }

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_event_rule" "schedule" {
   name                = "${var.prefix}es-cleanup-execution-schedule"
-  description         = "es-cleanup execution schedule"
+  description         = "${var.prefix}es-cleanup execution schedule"
   schedule_expression = "${var.schedule}"
 }
 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -32,3 +32,9 @@ resource "aws_iam_role_policy_attachment" "policy_attachment" {
   role       = "${aws_iam_role.role.name}"
   policy_arn = "${aws_iam_policy.policy.arn}"
 }
+
+resource "aws_iam_role_policy_attachment" "vpc-execution" {
+  count      = "${length(var.subnet_ids) > 0 ? 1 : 0}"
+  role       = "${aws_iam_role.role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -5,7 +5,7 @@ data "template_file" "policy" {
 resource "aws_iam_policy" "policy" {
   name        = "${var.prefix}es-cleanup"
   path        = "/"
-  description = "Policy for es-cleanup Lambda function"
+  description = "Policy for ${var.prefix}es-cleanup Lambda function"
   policy      = "${data.template_file.policy.rendered}"
 }
 
@@ -33,7 +33,7 @@ resource "aws_iam_role_policy_attachment" "policy_attachment" {
   policy_arn = "${aws_iam_policy.policy.arn}"
 }
 
-resource "aws_iam_role_policy_attachment" "vpc-execution" {
+resource "aws_iam_role_policy_attachment" "policy_attachment_vpc" {
   count      = "${length(var.subnet_ids) > 0 ? 1 : 0}"
   role       = "${aws_iam_role.role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -5,21 +5,26 @@ data "archive_file" "es_cleanup_lambda" {
 }
 
 resource "aws_lambda_function" "es_cleanup" {
-    filename         = "${path.module}/es-cleanup.zip"
-    function_name    = "${var.prefix}es-cleanup"
-    timeout          = 300
-    runtime          = "python${var.python_version}"
-    role             = "${aws_iam_role.role.arn}"
-    handler          = "es-cleanup.lambda_handler"
-    source_code_hash = "${data.archive_file.es_cleanup_lambda.output_base64sha256}"
+  filename         = "${path.module}/es-cleanup.zip"
+  function_name    = "${var.prefix}es-cleanup"
+  timeout          = 300
+  runtime          = "python${var.python_version}"
+  role             = "${aws_iam_role.role.arn}"
+  handler          = "es-cleanup.lambda_handler"
+  source_code_hash = "${data.archive_file.es_cleanup_lambda.output_base64sha256}"
 
-    environment {
-        variables = {
-            es_endpoint  = "${var.es_endpoint}"
-            index        = "${var.index}"
-            delete_after = "${var.delete_after}"
-            index_format = "${var.index_format}"
-            sns_alert    = "${var.sns_alert}"
-        }
+  environment {
+    variables = {
+      es_endpoint  = "${var.es_endpoint}"
+      index        = "${var.index}"
+      delete_after = "${var.delete_after}"
+      index_format = "${var.index_format}"
+      sns_alert    = "${var.sns_alert}"
     }
+  }
+
+  vpc_config {
+    subnet_ids         = ["${var.subnet_ids}"]
+    security_group_ids = ["${aws_security_group.lambda.*.id}"]
+  }
 }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -7,6 +7,7 @@ data "archive_file" "es_cleanup_lambda" {
 resource "aws_lambda_function" "es_cleanup" {
   filename         = "${path.module}/es-cleanup.zip"
   function_name    = "${var.prefix}es-cleanup"
+  description      = "${var.prefix}es-cleanup"
   timeout          = 300
   runtime          = "python${var.python_version}"
   role             = "${aws_iam_role.role.arn}"
@@ -23,6 +24,10 @@ resource "aws_lambda_function" "es_cleanup" {
     }
   }
 
+  tags = "${merge(
+            var.tags,
+            map("Scope", "${var.prefix}lambda_function_to_elasticsearch"),
+            )}"
   # This will be a code block with empty lists if we don't create a securitygroup and the subnet_ids are empty.
   # When these lists are empty it will deploy the lambda without VPC support.
   vpc_config {

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -23,6 +23,8 @@ resource "aws_lambda_function" "es_cleanup" {
     }
   }
 
+  # This will be a code block with empty lists if we don't create a securitygroup and the subnet_ids are empty.
+  # When these lists are empty it will deploy the lambda without VPC support.
   vpc_config {
     subnet_ids         = ["${var.subnet_ids}"]
     security_group_ids = ["${aws_security_group.lambda.*.id}"]

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -4,7 +4,8 @@ data "archive_file" "es_cleanup_lambda" {
   output_path = "${path.module}/es-cleanup.zip"
 }
 
-resource "aws_lambda_function" "es_cleanup" {
+resource "aws_lambda_function" "es_cleanup_vpc" {
+  count            = "${length(var.subnet_ids) > 0 ? 1 : 0}"
   filename         = "${path.module}/es-cleanup.zip"
   function_name    = "${var.prefix}es-cleanup"
   description      = "${var.prefix}es-cleanup"
@@ -34,4 +35,33 @@ resource "aws_lambda_function" "es_cleanup" {
     subnet_ids         = ["${var.subnet_ids}"]
     security_group_ids = ["${aws_security_group.lambda.*.id}"]
   }
+}
+
+
+
+resource "aws_lambda_function" "es_cleanup" {
+  count            = "${length(var.subnet_ids) == 0 ? 1 : 0}"
+  filename         = "${path.module}/es-cleanup.zip"
+  function_name    = "${var.prefix}es-cleanup"
+  description      = "${var.prefix}es-cleanup"
+  timeout          = 300
+  runtime          = "python${var.python_version}"
+  role             = "${aws_iam_role.role.arn}"
+  handler          = "es-cleanup.lambda_handler"
+  source_code_hash = "${data.archive_file.es_cleanup_lambda.output_base64sha256}"
+
+  environment {
+    variables = {
+      es_endpoint  = "${var.es_endpoint}"
+      index        = "${var.index}"
+      delete_after = "${var.delete_after}"
+      index_format = "${var.index_format}"
+      sns_alert    = "${var.sns_alert}"
+    }
+  }
+
+  tags = "${merge(
+            var.tags,
+            map("Scope", "${var.prefix}lambda_function_to_elasticsearch"),
+            )}"
 }

--- a/terraform/sg.tf
+++ b/terraform/sg.tf
@@ -1,0 +1,38 @@
+data "aws_subnet" "selected" {
+  count = "${length(var.subnet_ids) > 0 ? 1 : 0}"
+  id    = "${var.subnet_ids[0]}"
+}
+
+resource "aws_security_group" "lambda" {
+  count       = "${length(var.subnet_ids) > 0 ? 1 : 0}"
+  name        = "lambda_cleanup_to_elasticsearch_${var.prefix}"
+  description = "Lambda sg for cleanup function to elasticsearch"
+  vpc_id      = "${data.aws_subnet.selected.vpc_id}"
+
+  tags {
+    Name        = "lambda_function_to_elasticsearch_${var.prefix}"
+    Environment = "${var.prefix}"
+  }
+}
+
+resource "aws_security_group_rule" "lambda_to_es" {
+  count                    = "${length(var.subnet_ids) > 0 ? 1 : 0}"
+  type                     = "egress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = "${var.elasticsearch_sg_id}"
+
+  security_group_id = "${aws_security_group.lambda.id}"
+}
+
+resource "aws_security_group_rule" "es_from_lambda" {
+  count                    = "${length(var.subnet_ids) > 0 ? 1 : 0}"
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.lambda.id}"
+
+  security_group_id = "${var.elasticsearch_sg_id}"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,7 +20,7 @@ variable "index" {
 
 variable "delete_after" {
   description = "Numbers of days to preserve"
-  default     = 7
+  default     = 15
 }
 
 variable "index_format" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,16 +7,26 @@ variable "schedule" {
 }
 
 variable "sns_alert" {
-  default = ""
+  description = "SNS ARN to pusblish any alert"
+  default     = ""
 }
 
 variable "es_endpoint" {}
 
-variable "index" {}
+variable "index" {
+  description = "Index/indices to process comma separated, with all every index will be processed except '.kibana'"
+  default     = "all"
+}
 
-variable "delete_after" {}
+variable "delete_after" {
+  description = "Numbers of days to preserve"
+  default     = 7
+}
 
-variable "index_format" {}
+variable "index_format" {
+  description = "Combined with 'index' varible is used to evaluate the index age"
+  default     = "%Y.%m.%d"
+}
 
 variable "python_version" {
   default = "2.7"
@@ -28,7 +38,9 @@ variable "subnet_ids" {
   default     = []
 }
 
-variable "elasticsearch_sg_id" {
-  description = "Security group ID of the AWS elasticsearch service. Only fill this in if you deploy Lambda function inside a VPC."
-  default     = ""
+variable "tags" {
+  description = "Tags to apply"
+  default = {
+    Name = "es-cleanup"
+  }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,11 +38,6 @@ variable "subnet_ids" {
   default     = []
 }
 
-variable "elasticsearch_sg_id" {
-  description = "Security group ID of the AWS elasticsearch service"
-  default     = ""
-}
-
 variable "tags" {
   description = "Tags to apply"
   default = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,6 +38,11 @@ variable "subnet_ids" {
   default     = []
 }
 
+variable "elasticsearch_sg_id" {
+  description = "Security group ID of the AWS elasticsearch service"
+  default     = ""
+}
+
 variable "tags" {
   description = "Tags to apply"
   default = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,8 +1,14 @@
-variable "prefix" {  default = "" }
+variable "prefix" {
+  default = ""
+}
 
-variable "schedule" { default = "cron(0 3 * * ? *)" }
+variable "schedule" {
+  default = "cron(0 3 * * ? *)"
+}
 
-variable "sns_alert" { default = "" }
+variable "sns_alert" {
+  default = ""
+}
 
 variable "es_endpoint" {}
 
@@ -12,4 +18,17 @@ variable "delete_after" {}
 
 variable "index_format" {}
 
-variable "python_version" { default = "2.7" }
+variable "python_version" {
+  default = "2.7"
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs you want to deploy the lambda in. Only fill this in if you want to deploy your Lambda function inside a VPC."
+  type        = "list"
+  default     = []
+}
+
+variable "elasticsearch_sg_id" {
+  description = "Security group ID of the AWS elasticsearch service. Only fill this in if you deploy Lambda function inside a VPC."
+  default     = ""
+}


### PR DESCRIPTION
When your Elasticsearch is running inside your VPC, you also need to run your Lambda function inside your VPC. This is the groundwork to make it possible.
We need to do the following:
- Create securitygroup for Lambda + open ports both on Lambda and Elasticsearch side
- Extend IAM role to allow VPC execution
- Add the variables subnet_ids and the elasticsearch securitygroup

When subnet_ids and elasticsearch_sg_id are empty it will create the lambda without VPC support. These changes are backwards compatible and will not break previous behaviour.

I tested this change the following ways
Without VPC
```
module "es_cleanup" {
  source = "<path_to_module>/aws-lambda-es-cleanup/terraform"

  prefix       = "test-"
  es_endpoint  = "https://es-endpoint.test"
  index        = "cwl"
  delete_after = 31
  index_format = "%Y.%m.%d"
  python_version = "3.6"
}
```

With VPC support
```
module "es_cleanup" {
  source = "<path_to_module>/aws-lambda-es-cleanup/terraform"

  prefix       = "test-"
  es_endpoint  = "https://es-endpoint.test"
  es_endpoint  = "${data.terraform_remote_state.elasticsearch.es_logs_endpoint}"
  index        = "cwl"
  delete_after = 31
  index_format = "%Y.%m.%d"
  python_version = "3.6"
  subnet_ids          = ["<subnet_id"]
  elasticsearch_sg_id = "sg-xxxx"
}
```

Plan of without shows this
```
  + module.es_cleanup.aws_lambda_function.es_cleanup
      id:                                   <computed>
      arn:                                  <computed>
      environment.#:                        "1"
      environment.0.variables.%:            "5"
      environment.0.variables.delete_after: "31"
      environment.0.variables.es_endpoint:  "https://es-endpoint.test"
      environment.0.variables.index:        "cwl"
      environment.0.variables.index_format: "%Y.%m.%d"
      environment.0.variables.sns_alert:    ""
      filename:                             "/Users/stacks/cwlogs-to-es/.terraform/modules/6894bcd4a8a3d05d502dd16ebb78c508/es-cleanup.zip"
      function_name:                        "test-es-cleanup"
      handler:                              "es-cleanup.lambda_handler"
      invoke_arn:                           <computed>
      last_modified:                        <computed>
      memory_size:                          "128"
      publish:                              "false"
      qualified_arn:                        <computed>
      role:                                 "${aws_iam_role.role.arn}"
      runtime:                              "python3.6"
      source_code_hash:                     "oSpCIkdW1m/XxRRvbD8CC8t2XpXSjI52r1djIT0ZA6E="
      timeout:                              "300"
      tracing_config.#:                     <computed>
      version:                              <computed>
      vpc_config.#:                         "1"
      vpc_config.0.vpc_id:                  <computed>
```

After deploy I checked the Lambda function
<img width="676" alt="screen shot 2018-02-27 at 17 58 19" src="https://user-images.githubusercontent.com/2216724/36742406-d60caeea-1be7-11e8-8f2d-524081d0679e.png">
