### PR TITLE
Fix index name parsed incorrectly if index format contains hyphen

### DIFF
--- a/es-cleanup.py
+++ b/es-cleanup.py
@@ -183,8 +183,10 @@ def lambda_handler(event, context):
             # ignore .kibana index
             continue
 
-        idx_name = '-'.join(word for word in index["index"].split("-")[:-1])
-        idx_date = index["index"].split("-")[-1]
+        idx_split = index["index"].rsplit("-",
+            1 + es.cfg["index_format"].count("-"))
+        idx_name = idx_split[0]
+        idx_date = '-'.join(word for word in idx_split[1:])
 
         if idx_name in es.cfg["index"] or "all" in es.cfg["index"]:
 


### PR DESCRIPTION
If index format contains hyphen such as `index-2018-08-11`, the index date
is parsed as `index-2018-08` rather than `index`.

I run into this problem using Kinesis Firehose which creates index in [this format](https://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#es-index-rotation). 