### PR TITLE
JSON encoding for payload

### DIFF
--- a/es-cleanup.py
+++ b/es-cleanup.py
@@ -14,6 +14,8 @@ from botocore.awsrequest import AWSRequest
 from botocore.credentials import create_credential_resolver
 from botocore.session import get_session
 from botocore.vendored.requests import Session
+from json import dumps
+
 import sys
 if sys.version_info[0] == 3:
     from urllib.request import quote
@@ -107,7 +109,7 @@ class ES_Cleanup(object):
                 method=method,
                 url="https://{}{}?pretty&format=json".format(
                     self.cfg["es_endpoint"], quote(path)),
-                data=payload,
+                data=dumps(payload),
                 headers={'Host': self.cfg["es_endpoint"]})
             credential_resolver = create_credential_resolver(get_session())
             credentials = credential_resolver.load_credentials()


### PR DESCRIPTION
without JSON encoding for payload dictionary, will get error as below:
{"error":{"root_cause":[{"type":"not_x_content_exception","reason":"Compressor detection can only be called on some xcontent bytes or compressed xcontent bytes"}],"type":"not_x_content_exception","reason":"Compressor detection can only be called on some xcontent bytes or compressed xcontent bytes"},"status":500}