### PR TITLE
Use a relative path to prevent spurious terraform changes.

### DIFF
--- a/es-cleanup.py
+++ b/es-cleanup.py
@@ -166,7 +166,7 @@ def lambda_handler(event, context):
     earliest_to_keep = datetime.date.today() - datetime.timedelta(
         days=int(es.cfg["delete_after"]))
     for index in es.get_indices():
-
+        print("Found index: %s", index["index"])
         if index["index"] == ".kibana":
             # ignore .kibana index
             continue
@@ -181,6 +181,10 @@ def lambda_handler(event, context):
             if idx_date <= earliest_to_keep.strftime(es.cfg["index_format"]):
                 print("Deleting index: %s" % index["index"])
                 es.delete_index(index["index"])
+            else:
+                print("Keeping index: %s" % index["index"])
+        else:
+            print("Index %s name %s did not match pattern %s", index["index"], idx_name, es.cfg["index"])
 
 
 if __name__ == '__main__':

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -8,9 +8,15 @@ locals {
   sg_ids = ["${element(concat(aws_security_group.lambda.*.id, list("")), 0)}"]
 }
 
+data "null_data_source" "lambda_file" {
+  inputs {
+    filename = "${substr("${path.module}/es-cleanup.zip", length(path.cwd) + 1, -1)}"
+
+  }
+}
 
 resource "aws_lambda_function" "es_cleanup" {
-  filename         = "${path.module}/es-cleanup.zip"
+  filename         = "${data.null_data_source.lambda_file.outputs.filename}"
   function_name    = "${var.prefix}es-cleanup${var.suffix}"
   description      = "${var.prefix}es-cleanup${var.suffix}"
   timeout          = 300


### PR DESCRIPTION
The terraform filename parameter encodes an absolute path to the module,
which can be different when run on different machines. This changes it
to key on a relative path, per the recommendation here:

https://github.com/hashicorp/terraform/issues/7613#issuecomment-384454889