### PR TITLE
Automate snapshots

### DIFF
--- a/es-cleanup.py
+++ b/es-cleanup.py
@@ -164,7 +164,7 @@ class ES_Cleanup(object):
         }
 
         # Append a timestamp to deduplicate multiple snapshots for same index
-        now = str(datetime.datetime.now())
+        now = str(datetime.datetime.now().timestamp())
         snapshot_name = "{}_{}".format(index_name, now)
 
         # create snapshot

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -26,11 +26,14 @@ resource "aws_lambda_function" "es_cleanup" {
 
   environment {
     variables = {
-      es_endpoint  = var.es_endpoint
-      index        = var.index
-      skip_index   = var.skip_index
-      delete_after = var.delete_after
-      index_format = var.index_format
+      es_endpoint           = var.es_endpoint
+      index                 = var.index
+      skip_index            = var.skip_index
+      delete_after          = var.delete_after
+      index_format          = var.index_format
+      snapshot_enabled      = var.snapshot_enabled
+      snapshot_repository   = var.snapshot_repository
+      snapshot_delete_after = var.snapshot_delete_after
     }
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,6 +28,21 @@ variable "delete_after" {
   default     = 15
 }
 
+variable "snapshot_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "snapshot_repository" {
+  type    = string
+  default = ""
+}
+
+variable "snapshot_delete_after" {
+  description = "Numbers of days to preserve snapshots"
+  default     = 15
+}
+
 variable "index_format" {
   description = "Combined with 'index' varible is used to evaluate the index age"
   default     = "%Y.%m.%d"


### PR DESCRIPTION
Creates a snapshot before deleting an index.

Snapshots are also rotated every `snapshot_delete_after` days
