### PR TITLE
Fix Logic, Improve Test Coverage, and Resilience 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
 Create your Lambda package
 
 ```bash
-$ zip es-cleanup-lambda.zip es-cleanup.py
+$ zip es-cleanup-lambda.zip es_cleanup.py
 ```
 
 

--- a/es_cleanup.py
+++ b/es_cleanup.py
@@ -197,14 +197,14 @@ def lambda_handler(event, context):
         None
     """
     es = ES_Cleanup(event, context)
-    should_delete = delete_decider(delete_after=int(es.cfg["delete_after"]),
+    decider = DeleteDecider(delete_after=int(es.cfg["delete_after"]),
                                    idx_regex=es.cfg["index"],
                                    idx_format=es.cfg["index_format"],
                                    skip_idx_regex=es.cfg["skip_index"],
                                    today=datetime.date.today())
 
     for index in es.get_indices():
-        d, reason = should_delete(index)
+        d, reason = decider.should_delete(index)
         if d:
             print("Deleting index: {}".format(index["index"]))
             es.delete_index(index["index"])

--- a/es_cleanup.py
+++ b/es_cleanup.py
@@ -3,17 +3,18 @@
 """
 This AWS Lambda function allowed to delete the old Elasticsearch index
 """
-import re
-import os
-import json
-import time
 import datetime
+import re
+import sys
+import time
+
+import json
+import os
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from botocore.credentials import create_credential_resolver
 from botocore.httpsession import URLLib3Session
 from botocore.session import get_session
-import sys
 
 if sys.version_info[0] == 3:
     from urllib.request import quote
@@ -198,10 +199,10 @@ def lambda_handler(event, context):
     """
     es = ES_Cleanup(event, context)
     decider = DeleteDecider(delete_after=int(es.cfg["delete_after"]),
-                                   idx_regex=es.cfg["index"],
-                                   idx_format=es.cfg["index_format"],
-                                   skip_idx_regex=es.cfg["skip_index"],
-                                   today=datetime.date.today())
+                            idx_regex=es.cfg["index"],
+                            idx_format=es.cfg["index_format"],
+                            skip_idx_regex=es.cfg["skip_index"],
+                            today=datetime.date.today())
 
     for index in es.get_indices():
         d, reason = decider.should_delete(index)

--- a/es_cleanup_test.py
+++ b/es_cleanup_test.py
@@ -28,7 +28,7 @@ class TestShouldDelete(unittest.TestCase):
             should_delete1({"index": "k8s-2019-12-15"})
 
     def test_should_skip_indes(self):
-        tuple = should_delete1({"index": "kibana-kjsdjkabsklcjukcd"})
+        tuple = should_delete1({"index": ".kibana"})
         self.assertFalse(tuple[0])
         self.assertTrue("matches skip condition" in tuple[1])
 

--- a/es_cleanup_test.py
+++ b/es_cleanup_test.py
@@ -1,0 +1,36 @@
+import datetime
+import unittest
+
+import es_cleanup
+
+IDX_REGEX = '.*'
+IDX_FORMAT1 = '%Y.%m.%d'
+SKIP_IDX_REGEX = 'kibana*'
+
+should_delete1 = es_cleanup.delete_decider(delete_after=4,
+                                           idx_format=IDX_FORMAT1,
+                                           idx_regex=IDX_REGEX,
+                                           skip_idx_regex=SKIP_IDX_REGEX,
+                                           today=datetime.date(2019, 12, 19))
+
+
+class TestShouldDelete(unittest.TestCase):
+    def test_should_be_deleted(self):
+        tuple = should_delete1({"index": "k8s-2019.12.14"})
+        self.assertTrue(tuple[0])
+
+    def test_should_not_be_deleted(self):
+        tuple = should_delete1({"index": "k8s-2019.12.15"})
+        self.assertFalse(tuple[0])
+
+    def test_should_raise_value_error(self):
+        with self.assertRaises(ValueError):
+            should_delete1({"index": "k8s-2019-12-15"})
+
+    def test_should_skip_indes(self):
+        tuple = should_delete1({"index": "kibana-kjsdjkabsklcjukcd"})
+        self.assertFalse(tuple[0])
+        self.assertTrue("matches skip condition" in tuple[1])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/es_cleanup_test.py
+++ b/es_cleanup_test.py
@@ -7,28 +7,28 @@ IDX_REGEX = '.*'
 IDX_FORMAT1 = '%Y.%m.%d'
 SKIP_IDX_REGEX = 'kibana*'
 
-should_delete1 = es_cleanup.delete_decider(delete_after=4,
-                                           idx_format=IDX_FORMAT1,
-                                           idx_regex=IDX_REGEX,
-                                           skip_idx_regex=SKIP_IDX_REGEX,
-                                           today=datetime.date(2019, 12, 19))
+decider = es_cleanup.DeleteDecider(delete_after=4,
+                                   idx_format=IDX_FORMAT1,
+                                   idx_regex=IDX_REGEX,
+                                   skip_idx_regex=SKIP_IDX_REGEX,
+                                   today=datetime.date(2019, 12, 19))
 
 
 class TestShouldDelete(unittest.TestCase):
     def test_should_be_deleted(self):
-        tuple = should_delete1({"index": "k8s-2019.12.14"})
+        tuple = decider.should_delete({"index": "k8s-2019.12.14"})
         self.assertTrue(tuple[0])
 
     def test_should_not_be_deleted(self):
-        tuple = should_delete1({"index": "k8s-2019.12.15"})
+        tuple = decider.should_delete({"index": "k8s-2019.12.15"})
         self.assertFalse(tuple[0])
 
     def test_should_raise_value_error(self):
         with self.assertRaises(ValueError):
-            should_delete1({"index": "k8s-2019-12-15"})
+            decider.should_delete({"index": "k8s-2019-12-15"})
 
     def test_should_skip_indes(self):
-        tuple = should_delete1({"index": ".kibana"})
+        tuple = decider.should_delete({"index": ".kibana"})
         self.assertFalse(tuple[0])
         self.assertTrue("matches skip condition" in tuple[1])
 

--- a/es_cleanup_test.py
+++ b/es_cleanup_test.py
@@ -32,5 +32,6 @@ class TestShouldDelete(unittest.TestCase):
         self.assertFalse(tuple[0])
         self.assertTrue("matches skip condition" in tuple[1])
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/serverless.yml
+++ b/serverless.yml
@@ -39,7 +39,7 @@ functions:
       exclude:
         - ./**
       include:
-        - es-cleanup.py
+        - es_cleanup.py
         - LICENSE.md
         - README.md
         - CONTRIBUTING.md

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,6 +1,6 @@
 data "archive_file" "es_cleanup_lambda" {
   type        = "zip"
-  source_file = "${path.module}/../es-cleanup.py"
+  source_file = "${path.module}/../es_cleanup.py"
   output_path = "${path.module}/es-cleanup.zip"
 }
 


### PR DESCRIPTION
- When using an incorrect date pattern for the index format, the comparison of date stings meant that incorrect results could occur. This has lead to unintended deletion of data in our environment. This PR fixes this by comparing Python Date objects instead.
- It looks to me like the use of `<=` in the comparison meant that one more day than intended was deleted. See code.
- The decision logic is factored out into a pure function which is easily testable.
- Some unit tests have been added.
- In order to be able to import the module from the unit test file, I needed to rename the file. Module names with dashes cannot be easily imported.